### PR TITLE
Changing the plot interface to finally make the plotting work

### DIFF
--- a/Part2_colour-mapping.ipynb
+++ b/Part2_colour-mapping.ipynb
@@ -28,8 +28,8 @@
     }
    },
    "source": [
-    "# %matplotlib inline\n",
-    "%matplotlib notebook\n",
+    "%matplotlib inline\n",
+    "# %matplotlib notebook\n",
     "import os\n",
     "import h5py\n",
     "import math\n",


### PR DESCRIPTION
Part 2: use matplotlib inline instead of matplotlib notebook, as the second one throws an IPython error in Binder.